### PR TITLE
handle error code 1001

### DIFF
--- a/algorithms/algorithms.go
+++ b/algorithms/algorithms.go
@@ -465,6 +465,11 @@ func WsUserDataServe(
 		})
 
 		switch {
+		case strings.Contains(err.Error(), "1001"):
+			/* -1001 DISCONNECTED Internal error; unable to process your request. Please try again. */
+
+			exchange.GetClient(configData, sessionData) /* Reconnect exchange client */
+
 		case strings.Contains(err.Error(), "1006"):
 			/* -1006 UNEXPECTED_RESP An unexpected response was received from the message bus. Execution status unknown. */
 			/* Error Codes for Binance https://github.com/binance/binance-spot-api-docs/blob/master/errors.md */
@@ -561,6 +566,11 @@ func WsKline(
 			/* -unexpected EOF An unexpected response was received from the message bus. Execution status unknown. */
 
 			return
+
+		case strings.Contains(err.Error(), "1001"):
+			/* -1001 DISCONNECTED Internal error; unable to process your request. Please try again. */
+
+			exchange.GetClient(configData, sessionData) /* Reconnect exchange client */
 
 		}
 


### PR DESCRIPTION
Hi Andre,

Here is a fix for an unhandled error that caused the bot to disconnect from binance server.

```
time="2021-08-05 02:44:01" level=debug msg="cryptopump/algorithms.WsKline.func2 - websocket: close 1001 (going away)" orderID=0 threadID=c435ggsrs38slni7mhhg
time="2021-08-05 04:40:02" level=debug msg="cryptopump/algorithms.WsUserDataServe.func2 - websocket: close 1001 (going away)" orderID=0 threadID=c435ggsrs38slni7mhhg
```

It is not easy to reproduce the error to verify the fix, not until it happened again at least..